### PR TITLE
Button and logo fixes for podcast.adobe.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17541,6 +17541,25 @@ ymaps[class$="ground-pane"]
 
 ================================
 
+podcast.adobe.com
+
+INVERT
+.bWTYPJ
+.cylKGQ
+sp-action-button > img
+.track
+footer > img
+
+CSS
+sp-button.sc-eSNLA-D.joqRAB {
+    background-color: ${black} !important;
+}
+sp-button.sc-eSNLA-D.joqRAB > span {
+    color: ${white} !important;
+}
+
+================================
+
 pocketbase.io
 
 INVERT


### PR DESCRIPTION
Added fixes for the play button:
![image](https://github.com/rappos/darkreader/assets/6437769/eb9ef369-b676-4a4c-80c8-1faff0635997)
and for the logos in navbar and footer:
![image](https://github.com/rappos/darkreader/assets/6437769/cb589e3e-b48a-4225-b622-e1929124284c)
